### PR TITLE
Security: bump Next.js (critical), redact webhook in doc, warn on client-side key variant

### DIFF
--- a/assess.html
+++ b/assess.html
@@ -455,6 +455,21 @@ function submitAssessment() {
 }
 
 function callClaude(prompt) {
+  /* ===================================================================================
+   * !!! SECURITY WARNING — DO NOT DEPLOY THIS STATIC VARIANT (assess.html) !!!
+   * ===================================================================================
+   * This browser-side call to api.anthropic.com is an ANTI-PATTERN. It requires an
+   * Anthropic API key to be present client-side (window.ANTHROPIC_API_KEY), which would
+   * expose the key to every visitor via view-source / the network inspector. The
+   * 'anthropic-dangerous-direct-browser-access' header only exists for local experiments.
+   *
+   * This file is the STATIC prototype variant. It MUST NEVER be deployed to production and
+   * MUST NEVER have an API key injected client-side. No key is committed today (the global
+   * is empty) — keep it that way.
+   *
+   * The live site (va-ai-futures.buildfirst.io) uses the SERVER-SIDE Next.js /api/analyze
+   * route in va-futures-code/, which keeps the key on the server. That is the correct path.
+   * =================================================================================== */
   var key = window.ANTHROPIC_API_KEY || '';
   if (!key) return Promise.reject(new Error('API key not configured'));
 

--- a/docs/make-com-setup-prompt.md
+++ b/docs/make-com-setup-prompt.md
@@ -15,7 +15,7 @@ I have a Virginia AI Futures assessment at `assess.html` that:
 4. Displays results on the page
 5. Sends a webhook POST to Make.com with all the data + a pre-rendered HTML email
 
-I already have a separate Make.com scenario for my BuildFirst assessment (webhook: `https://hook.us2.make.com/96ptcm5uiskujpx9p2iuqrm5nqn1jcxq`). **This new scenario must be completely separate. Do not modify the existing BuildFirst scenario.**
+I already have a separate Make.com scenario for my BuildFirst assessment (webhook: `https://hook.us2.make.com/<YOUR_WEBHOOK_ID>`). **This new scenario must be completely separate. Do not modify the existing BuildFirst scenario.**
 
 ## What the Webhook Receives
 

--- a/va-futures-code/package-lock.json
+++ b/va-futures-code/package-lock.json
@@ -12,7 +12,7 @@
         "@vercel/analytics": "^2.0.1",
         "chart.js": "^4.5.1",
         "lucide-react": "^0.395.0",
-        "next": "14.2.0",
+        "next": "^14.2.35",
         "react": "^18",
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^18"
@@ -108,15 +108,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.0.tgz",
-      "integrity": "sha512-4+70ELtSbRtYUuyRpAJmKC8NHBW2x1HMje9KO2Xd7IkoyucmV9SjgO+qeWMC0JWkRQXgydv1O7yKOK8nu/rITQ==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.0.tgz",
-      "integrity": "sha512-kHktLlw0AceuDnkVljJ/4lTJagLzDiO3klR1Fzl2APDFZ8r+aTxNaNcPmpp0xLMkgRwwk6sggYeqq0Rz9K4zzA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.0.tgz",
-      "integrity": "sha512-HFSDu7lb1U3RDxXNeKH3NGRR5KyTPBSUTuIOr9jXoAso7i76gNYvnTjbuzGVWt2X5izpH908gmOYWtI7un+JrA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.0.tgz",
-      "integrity": "sha512-iQsoWziO5ZMxDWZ4ZTCAc7hbJ1C9UDj/gATSqTaMjW2bJFwAsvf9UM79AKnljBl73uPZ+V0kH4rvnHTco4Ps2w==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.0.tgz",
-      "integrity": "sha512-0JOk2uzLUt8fJK5LpsKKZa74zAch7bJjjgJzR9aOMs231AlE4gPYzsSm430ckZitjPGKeH5bgDZjqwqJQKIS2w==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.0.tgz",
-      "integrity": "sha512-uYHkuTzX0NM6biKNp7hdKTf+BF0iMV254SxO0B8PgrQkxUBKGmk5ysHKB+FYBfdf9xei/t8OIKlXJs9ckD943A==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
       ],
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.0.tgz",
-      "integrity": "sha512-paN89nLs2dTBDtfXWty1/NVPit+q6ldwdktixYSVwiiAz647QDCd+EIYqoiS+/rPG3oXs/A7rWcJK9HVqfnMVg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
       ],
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.0.tgz",
-      "integrity": "sha512-j1oiidZisnymYjawFqEfeGNcE22ZQ7lGUaa4pGOCVWrWeIDkPSj8zYgS9TzMNlg17Q3wSWCQC/F5uJAhSh7qcA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.0.tgz",
-      "integrity": "sha512-6ff6F4xb+QGD1jhx/dOT9Ot7PQ/GAYekV9ykwEh2EFS/cLTyU4Y3cXkX5cNtNIhpctS5NvyjW9gIksRNErYE0A==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.0.tgz",
-      "integrity": "sha512-09DbG5vXAxz0eTFSf1uebWD36GF3D5toynRkgo2AlSrxwGZkWtJ1RhmrczRYQ17eD5bdo4FZ0ibiffdq5kc4vg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
@@ -344,7 +344,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -526,7 +525,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -587,7 +585,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -892,7 +889,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -999,14 +995,12 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.0.tgz",
-      "integrity": "sha512-2T41HqJdKPqheR27ll7MFZ3gtTYvGew7cUc0PwPSyK9Ao5vvwpf9bYfP4V5YBGLckHF2kEGvrLte5BqLSv0s8g==",
-      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@next/env": "14.2.0",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -1021,15 +1015,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.0",
-        "@next/swc-darwin-x64": "14.2.0",
-        "@next/swc-linux-arm64-gnu": "14.2.0",
-        "@next/swc-linux-arm64-musl": "14.2.0",
-        "@next/swc-linux-x64-gnu": "14.2.0",
-        "@next/swc-linux-x64-musl": "14.2.0",
-        "@next/swc-win32-arm64-msvc": "14.2.0",
-        "@next/swc-win32-ia32-msvc": "14.2.0",
-        "@next/swc-win32-x64-msvc": "14.2.0"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -1212,7 +1206,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1421,7 +1414,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1444,7 +1436,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -1719,7 +1710,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/va-futures-code/package.json
+++ b/va-futures-code/package.json
@@ -13,7 +13,7 @@
     "@vercel/analytics": "^2.0.1",
     "chart.js": "^4.5.1",
     "lucide-react": "^0.395.0",
-    "next": "14.2.0",
+    "next": "^14.2.35",
     "react": "^18",
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^18"


### PR DESCRIPTION
Three scoped security fixes from a security review. No functional changes to the app.

## 1. Critical — bump Next.js in the deployed app (HIGH)
`va-futures-code/` is the server-side Next.js app that ships to `va-ai-futures.buildfirst.io`. It was pinned to `next@14.2.0`, which carries a critical rollup of advisories: authorization bypass, cache poisoning, SSRF, and DoS.

- Bumped `next` `14.2.0` → `14.2.35` (non-major, patch-level — exactly npm audit's own `fixAvailable`).
- Lockfile regenerated via `npm install next@14.2.35`.
- **Verification:** `npm run build` passes cleanly — all 23 routes compile, including the server-side `/api/analyze` route.

## 2. Webhook URL re-disclosed in a doc (LOW)
`docs/make-com-setup-prompt.md:18` repeated the buildfirst Make.com webhook URL. Replaced with a placeholder (`https://hook.us2.make.com/<YOUR_WEBHOOK_ID>`). Hygiene only — that endpoint is already public via buildfirst's client-side form, so this is not a new leak.

## 3. Client-side Anthropic-key anti-pattern — guard only (LOW)
`assess.html` is the **static** prototype variant (NOT the deployed build). Its `callClaude()` calls `api.anthropic.com` from the browser with `x-api-key` + `anthropic-dangerous-direct-browser-access`. No key is committed (the global is empty). Added a prominent warning comment at the call site: this variant must never be deployed and must never have a key injected client-side — the server-side `/api/analyze` route in `va-futures-code/` is the correct path. Functionality unchanged.

> Note: the warning was placed as a JS block comment rather than an HTML comment, because the call site lives inside a `<script>` block — a multi-line HTML comment there would break the script.

## Deferrals (out of scope for this PR)
`npm audit` in `va-futures-code/` still reports transitive dev-dependency advisories (picomatch, postcss) whose only fix is a breaking `next@16` major. Left untouched per the review's non-major constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015etrZBm8dFx69wtxmnBbHu

---
_Generated by [Claude Code](https://claude.ai/code/session_015etrZBm8dFx69wtxmnBbHu)_